### PR TITLE
I think the name in the reference to the license is a typo

### DIFF
--- a/README.org
+++ b/README.org
@@ -223,4 +223,4 @@
    #+END_SRC
 
 * License
-  Carthage is released under the [[https://github.com/xiaoxinghu/swift-org/blob/master/LICENSE][MIT LIcense]].
+  SwiftOrg is released under the [[https://github.com/xiaoxinghu/swift-org/blob/master/LICENSE][MIT LIcense]].


### PR DESCRIPTION
I hope I'm not misunderstanding, but this looks like a cut-and-paste error.